### PR TITLE
Pass lang dir to extension as an argument from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ You can enable the extension using your neon config.
 extensions:
 	console: Kdyby\Console\DI\ConsoleExtension
 	translationsConverter: Apploud\TranslationsConverter\DI\TranslationsConverterExtension
+		
+translationsConverter:
+	langDir: %appDir%/lang
 ```
 
 Usage
 ------------
 
-Simply use following commands to export translations into Excel or import into neon files. For now you need to have all language files inside `%appDir%/lang` and Excel file for import has to be named `translations.xlsx`.
+Simply use following commands to export translations into Excel or import into neon files. For now Excel file for import has to be named `translations.xlsx`. Directory with language files needs to be specified as `langDir` in neon config file.
 
 ```sh
 $ php www/index.php translations:export

--- a/src/Commands/ExportTranslationsCommand.php
+++ b/src/Commands/ExportTranslationsCommand.php
@@ -15,10 +15,10 @@ class ExportTranslationsCommand extends Command
 	/** @var string */
 	protected $langDir;
 
-	public function __construct($appDir)
+	public function __construct($langDir)
 	{
 		parent::__construct();
-		$this->langDir = $appDir . '/lang';
+		$this->langDir = $langDir;
 	}
 
 	protected function configure()

--- a/src/Commands/ImportTranslationsCommand.php
+++ b/src/Commands/ImportTranslationsCommand.php
@@ -15,10 +15,10 @@ class ImportTranslationsCommand extends Command
 	/** @var string */
 	protected $langDir;
 
-	public function __construct($appDir)
+	public function __construct($langDir)
 	{
 		parent::__construct();
-		$this->langDir = $appDir . '/lang';
+		$this->langDir = $langDir;
 	}
 
 	protected function configure()

--- a/src/DI/TranslationsConverterExtension.php
+++ b/src/DI/TranslationsConverterExtension.php
@@ -2,6 +2,7 @@
 
 namespace Apploud\TranslationsConverter\DI;
 
+use Apploud\TranslationsConverter\Exceptions\MissingParameterException;
 use Kdyby\Console\DI\ConsoleExtension;
 use Nette\DI\CompilerExtension;
 use Nette\DI\ServiceDefinition;
@@ -23,9 +24,16 @@ class TranslationsConverterExtension extends CompilerExtension
 
 	protected function getCommandServiceDefinition($commandClass)
 	{
+		$config = $this->getConfig();
+		$msg = "Parameter '%s' was not set.";
+
+		if (empty($config['langDir'])) {
+			throw new MissingParameterException(sprintf($msg, 'langDir'));
+		}
+
 		$command = new ServiceDefinition();
 		$command->addTag(ConsoleExtension::TAG_COMMAND);
-		$command->setClass($commandClass, ['appDir' => $this->getContainerBuilder()->parameters['appDir']]);
+		$command->setClass($commandClass, ['langDir' => $config['langDir']]);
 		$command->setInject(false);
 		return $command;
 	}

--- a/src/DI/TranslationsConverterExtension.php
+++ b/src/DI/TranslationsConverterExtension.php
@@ -25,7 +25,7 @@ class TranslationsConverterExtension extends CompilerExtension
 	protected function getCommandServiceDefinition($commandClass)
 	{
 		$config = $this->getConfig();
-		$msg = "Parameter '%s' was not set.";
+		$msg = "Parameter '%s' must be set in configuration file.";
 
 		if (empty($config['langDir'])) {
 			throw new MissingParameterException(sprintf($msg, 'langDir'));

--- a/src/Exceptions/MissingParameterException.php
+++ b/src/Exceptions/MissingParameterException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apploud\TranslationsConverter\Exceptions;
+
+class MissingParameterException extends \Exception
+{
+
+}

--- a/tests/files/config.neon
+++ b/tests/files/config.neon
@@ -3,3 +3,6 @@ php:
 extensions:
 	console: Kdyby\Console\DI\ConsoleExtension
 	translationsConverter: Apploud\TranslationsConverter\DI\TranslationsConverterExtension
+
+translationsConverter:
+	langDir: %appDir%/lang


### PR DESCRIPTION
The '/lang' directory remained hardcoded in tests.